### PR TITLE
Includes OCP friendly dockerfile

### DIFF
--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,0 +1,27 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
+WORKDIR /go/src/github.com/openshift/azure-disk-csi-driver
+COPY . .
+
+RUN make azuredisk
+
+FROM registry.ci.openshift.org/ocp/4.8:base
+COPY --from=builder /go/src/github.com/openshift/azure-disk-csi-driver/_output/azurediskplugin /bin/azurediskplugin
+RUN yum install -y util-linux e2fsprogs xfsprogs ca-certificates && yum clean all && rm -rf /var/cache/yum
+
+LABEL description="Azure Disk CSI Driver"
+
+ENTRYPOINT ["/bin/azurediskplugin"]


### PR DESCRIPTION
For OCP's build system it seems we need a different Dockerfile. This attempts to mirror some of our existing Dockerfiles, while also including the necessary binaries for the Azure Disk operations (such as mkfs).