### PR TITLE
Upstream 824: Bug 1949420: Adjust PVC capacity to mirror in-tree behavior

### DIFF
--- a/pkg/azuredisk/controllerserver.go
+++ b/pkg/azuredisk/controllerserver.go
@@ -306,7 +306,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      diskURI,
-			CapacityBytes: capacityBytes,
+			CapacityBytes: volumehelper.GiBToBytes(int64(requestGiB)),
 			VolumeContext: parameters,
 			ContentSource: contentSource,
 			AccessibleTopology: []*csi.Topology{

--- a/pkg/azuredisk/controllerserver_v2.go
+++ b/pkg/azuredisk/controllerserver_v2.go
@@ -268,7 +268,7 @@ func (d *DriverV2) CreateVolume(ctx context.Context, req *csi.CreateVolumeReques
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			VolumeId:      diskURI,
-			CapacityBytes: capacityBytes,
+			CapacityBytes: volumehelper.GiBToBytes(int64(requestGiB)),
 			VolumeContext: parameters,
 			ContentSource: contentSource,
 			AccessibleTopology: []*csi.Topology{


### PR DESCRIPTION
Backport of https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/824

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, if you request a 1MiB volume using the in-tree driver, then the corresponding created PVC has a capacity of 1 GiB. We currently create a backend disk that's rounded up to the nearest GiB, but the PVC uses the capacity initially specified, which is different from the in-tree driver.

This PR updates the CSi driver to 

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:

**Special notes for your reviewer**:

**Release note**:
```
Updates the CreateVolumeResponse to use a rounded GiB of the specified request.
```