### PR TITLE
Dockerfile should copy binary for the correct ARCH

### DIFF
--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,11 +1,10 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
 WORKDIR /go/src/github.com/openshift/azure-disk-csi-driver
 COPY . .
-
-RUN make azuredisk ARCH=$(go env GOARCH)
+RUN make azuredisk ARCH=$(go env GOARCH) && cp _output/$(go env GOARCH)/azurediskplugin .
 
 FROM registry.ci.openshift.org/ocp/4.11:base
-COPY --from=builder /go/src/github.com/openshift/azure-disk-csi-driver/_output/amd64/azurediskplugin /bin/azurediskplugin
+COPY --from=builder /go/src/github.com/openshift/azure-disk-csi-driver/azurediskplugin /bin/azurediskplugin
 RUN yum install -y util-linux e2fsprogs xfsprogs ca-certificates && yum clean all && rm -rf /var/cache/yum
 
 LABEL description="Azure Disk CSI Driver"


### PR DESCRIPTION
Follow up to https://github.com/openshift/azure-disk-csi-driver/pull/22
[Brew builds for ARM](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=43247601) are failing because the Dockerfile is still hardcoded to copy the binary from _output/amd64.
/cc @openshift/storage 