### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - hack/boilerplate/boilerplate.py


### PR DESCRIPTION
Ignore these two errors. boilerplate.py is only used to update the copyright headers, or to verify the headers during `make verify`. In either case, it does not grant the caller access to files that they would not already have access to.

```
 ✗ [Medium] Path Traversal
   ID: e8346a4e-270e-4133-bb34-05e63d5712d6 
   Path: hack/boilerplate/boilerplate.py, line 57 
   Info: Unsanitized input from a command line argument flows into open, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: bd89f292-215a-4991-a680-cc7aeb777560 
   Path: hack/boilerplate/boilerplate.py, line 173 
   Info: Unsanitized input from a command line argument flows into os.walk, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-azure-disk-csi-driver-master-security/1745954191009910784

/cc @openshift/storage
