### PR TITLE
OCPBUGS-27875: snyk should ignore deploy directory

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,3 +5,4 @@ exclude:
   global:
     - vendor/**
     - hack/boilerplate/boilerplate.py
+    - deploy/**


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-27875
Snyk reports issues in the `deploy` directory, which we do not use in OCP.
/cc @openshift/storage
