### PR TITLE
OCPBUGS-67186: fix: disk creation failure in AzureStack env

### DIFF
--- a/pkg/azuredisk/azure_managedDiskController.go
+++ b/pkg/azuredisk/azure_managedDiskController.go
@@ -159,10 +159,16 @@ func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *
 		BurstingEnabled: options.BurstingEnabled,
 	}
 
+	isAzureStack := azureutils.IsAzureStackCloud(c.cloud.Config.Cloud, c.cloud.Config.DisableAzureStackCloud)
+
 	if options.PublicNetworkAccess != "" {
 		diskProperties.PublicNetworkAccess = to.Ptr(options.PublicNetworkAccess)
 	} else {
-		diskProperties.PublicNetworkAccess = to.Ptr(armcompute.PublicNetworkAccessDisabled)
+		if isAzureStack {
+			klog.V(2).Infof("AzureDisk - PublicNetworkAccess is not supported in Azure Stack, skipping the property setting")
+		} else {
+			diskProperties.PublicNetworkAccess = to.Ptr(armcompute.PublicNetworkAccessDisabled)
+		}
 	}
 
 	if options.NetworkAccessPolicy != "" {
@@ -178,7 +184,11 @@ func (c *ManagedDiskController) CreateManagedDisk(ctx context.Context, options *
 			}
 		}
 	} else {
-		diskProperties.NetworkAccessPolicy = to.Ptr(armcompute.NetworkAccessPolicyDenyAll)
+		if isAzureStack {
+			klog.V(2).Infof("AzureDisk - NetworkAccessPolicy is not supported in Azure Stack, skipping the property setting")
+		} else {
+			diskProperties.NetworkAccessPolicy = to.Ptr(armcompute.NetworkAccessPolicyDenyAll)
+		}
 	}
 
 	if diskSku == armcompute.DiskStorageAccountTypesUltraSSDLRS || diskSku == armcompute.DiskStorageAccountTypesPremiumV2LRS {


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-67186

The PR cherry-picks the fix (`be1b3914d`) from upstream.