### PR TITLE
OCPBUGS-69390: fix ASH static provision segmentation fault

### DIFF
--- a/pkg/azureutils/azure_disk_utils.go
+++ b/pkg/azureutils/azure_disk_utils.go
@@ -737,7 +737,7 @@ func checkDiskName(diskName string) bool {
 	return true
 }
 
-// InsertProperties: insert disk properties to map
+// InsertDiskProperties inserts disk properties to map
 func InsertDiskProperties(disk *armcompute.Disk, publishConext map[string]string) {
 	if disk == nil || publishConext == nil {
 		return
@@ -748,7 +748,10 @@ func InsertDiskProperties(disk *armcompute.Disk, publishConext map[string]string
 	}
 	prop := disk.Properties
 	if prop != nil {
-		publishConext[consts.NetworkAccessPolicyField] = string(*prop.NetworkAccessPolicy)
+		// Azure stack hub does not have NetworkAccessPolicy property, so the prop.NetworkAccessPolicy will always be nil
+		if prop.NetworkAccessPolicy != nil {
+			publishConext[consts.NetworkAccessPolicyField] = string(*prop.NetworkAccessPolicy)
+		}
 		if prop.DiskIOPSReadWrite != nil {
 			publishConext[consts.DiskIOPSReadWriteField] = strconv.Itoa(int(*prop.DiskIOPSReadWrite))
 		}

--- a/pkg/azureutils/azure_disk_utils_test.go
+++ b/pkg/azureutils/azure_disk_utils_test.go
@@ -1637,6 +1637,28 @@ func TestInsertDiskProperties(t *testing.T) {
 				consts.MaxSharesField:           "3",
 			},
 		},
+		{
+			// Azure Stack does not support NetworkAccessPolicy property
+			desc: "DiskProperties with nil NetworkAccessPolicy",
+			disk: &armcompute.Disk{
+				SKU: &armcompute.DiskSKU{Name: to.Ptr(armcompute.DiskStorageAccountTypesStandardSSDLRS)},
+				Properties: &armcompute.DiskProperties{
+					NetworkAccessPolicy: nil,
+					DiskIOPSReadWrite:   ptr.To(int64(6400)),
+					DiskMBpsReadWrite:   ptr.To(int64(100)),
+					CreationData: &armcompute.CreationData{
+						LogicalSectorSize: ptr.To(int32(512)),
+					},
+				},
+			},
+			inputMap: map[string]string{},
+			expectedMap: map[string]string{
+				consts.SkuNameField:           string(armcompute.DiskStorageAccountTypesStandardSSDLRS),
+				consts.DiskIOPSReadWriteField: "6400",
+				consts.DiskMBPSReadWriteField: "100",
+				consts.LogicalSectorSizeField: "512",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
- Fix ASH static provision segmentation fault, the PR cherry-picks the fix (5d75c0413ec2737d3607843224f5bc88d52345a6) from upstream.